### PR TITLE
Removed named parameter from view model class registration in Autofac container

### DIFF
--- a/neo-gui/UI/MarkupExtensions/DataContextBindingExtension.cs
+++ b/neo-gui/UI/MarkupExtensions/DataContextBindingExtension.cs
@@ -34,8 +34,7 @@ namespace Neo.UI.MarkupExtensions
 
             if (target == null || DesignerProperties.GetIsInDesignMode(target)) return null;
 
-            var viewModelInstance = ApplicationContext.Instance.ContainerLifetimeScope
-                .Resolve<ViewModelBase>(new NamedParameter(nameof(this.ViewModel), this.ViewModel));
+            var viewModelInstance = ApplicationContext.Instance.ContainerLifetimeScope.Resolve(this.ViewModel);
 
             if (viewModelInstance is ILoadable loadableViewModel)
             {

--- a/neo-gui/UI/ViewModelsRegistrationModule.cs
+++ b/neo-gui/UI/ViewModelsRegistrationModule.cs
@@ -1,47 +1,19 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using Autofac;
-using Neo.UI.Accounts;
-using Neo.UI.Assets;
 using Neo.UI.Base.MVVM;
-using Neo.UI.Home;
-using Neo.UI.MarkupExtensions;
-using Neo.UI.Updater;
 
 namespace Neo.UI
 {
     public class ViewModelsRegistrationModule : Module
     {
-        private const string ViewModelTypeNameSuffix = "ViewModel";
-
         protected override void Load(ContainerBuilder builder)
         {
-            /*builder
-                .RegisterType<UpdateViewModel>()
-                .As<ViewModelBase>()
-                .WithParameter("ViewModel", "UpdateViewModel");
-            builder
-                .RegisterType<HomeViewModel>()
-                .As<ViewModelBase>()
-                .WithParameter("ViewModel", "HomeViewModel");
-            builder
-                .RegisterType<CreateMultiSigContractViewModel>()
-                .As<ViewModelBase>()
-                .WithParameter("ViewModel", "CreateMultiSigContractViewModel");
-            builder
-                .RegisterType<AssetDistributionViewModel>()
-                .As<ViewModelBase>()
-                .WithParameter("ViewModel", "AssetDistributionViewModel");*/
-
             var viewModelTypes = GetLoadedViewModelTypes();
 
             foreach (var viewModelType in viewModelTypes)
             {
-                builder
-                    .RegisterType(viewModelType)
-                    .As<ViewModelBase>()
-                    .WithParameter(nameof(DataContextBindingExtension.ViewModel), viewModelType);
+                builder.RegisterType(viewModelType);
             }
 
             base.Load(builder);


### PR DESCRIPTION
Fixes problem with Autofac container only returning the view model class that was registered last instead of the correct view model class