### PR TITLE
Added missing testnotifications resources

### DIFF
--- a/Neo.Gui.Wpf/App.xaml
+++ b/Neo.Gui.Wpf/App.xaml
@@ -6,7 +6,9 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/neo-gui;component/ResourceDictionaries/ConverterResources.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/neo-gui;component/ResourceDictionaries/StyleResources.xaml" />
-                
+
+                <!-- ToastNotifications resource dictionary -->
+                <ResourceDictionary Source="pack://application:,,,/ToastNotifications.Messages;component/Themes/Default.xaml" />
                 
                 <!-- MahApps resource dictionaries -->
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />


### PR DESCRIPTION
Added Missing ToastNotifications Resources
What current issue(s) from Trello/Github does this address?
None.

What problem does this PR solve?
The application crashes when transferring assets from one address to another.
> Open or create a new wallet and add an address with assets
> Click on Transfer
> Click on "+" (Add a payment).
> Fill assets / Destination Address / Amount and click "Ok"

How did you solve this problem?
Added the missing ToastNotification resource dictionary.

How did you make sure your solution works?
I tested it.

Are there any special changes in the code that we should be aware of?
None.

Is there anything else we should know?
No.