### PR TITLE
Fix crash on close TransactionOutputListBox

### DIFF
--- a/Neo.Gui.Wpf/Controls/TransactionOutputListBox.xaml.cs
+++ b/Neo.Gui.Wpf/Controls/TransactionOutputListBox.xaml.cs
@@ -125,7 +125,7 @@ namespace Neo.Gui.Wpf.Controls
             var result = dialogManager.ShowDialog<PayToDialogResult, PayToLoadParameters>(
                 new LoadParameters<PayToLoadParameters>(new PayToLoadParameters(this.Asset, this.ScriptHash)));
 
-            if (result.Output == null) return;
+            if (result?.Output == null) return;
 
             // Execute on main UI thread
             Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() =>


### PR DESCRIPTION
Description
What current issue(s) from Trello/Github does this address?
None.

What problem does this PR solve?
The application crash when closing the TransactionOutputListBox. (Null Ref Exception)
To reproduce: 
Start App > Create or Open new wallet and add an address > Click "Transfer" > Click "+" and click the close button (X).

How did you solve this problem?
Added a verification to see if result is null.

How did you make sure your solution works?
Tested it.

Are there any special changes in the code that we should be aware of?
Nop, but you might want to add a IsSuccess / IsError on your DialogResult.

Is there anything else we should know?
This is an example of a PR template and can be used as a template for PR templates in repos.