### PR TITLE
Remove code-behind from AssetDistributionView

### DIFF
--- a/Neo.Gui.ViewModels/Assets/AssetDistributionViewModel.cs
+++ b/Neo.Gui.ViewModels/Assets/AssetDistributionViewModel.cs
@@ -159,6 +159,11 @@ namespace Neo.Gui.ViewModels.Assets
         {
             this.AssetId = parameters?.AssetStateId;
             this.AssetIdEnabled = false;
+
+            this.Items.CollectionChanged += (sender, e) =>
+            {
+                RaisePropertyChanged(nameof(this.ConfirmEnabled));
+            };
         }
         #endregion
 
@@ -168,11 +173,6 @@ namespace Neo.Gui.ViewModels.Assets
             this.walletController.IssueAsset(this.Asset.Id, this.Items);
 
             this.Close(this, EventArgs.Empty);
-        }
-
-        public void UpdateConfirmButtonEnabled()
-        {
-            RaisePropertyChanged(nameof(this.ConfirmEnabled));
         }
 
         private void UpdateAssetDetails()

--- a/Neo.Gui.Wpf/Views/Assets/AssetDistributionView.xaml
+++ b/Neo.Gui.Wpf/Views/Assets/AssetDistributionView.xaml
@@ -1,13 +1,17 @@
-﻿<controls:NeoWindow x:Class="Neo.Gui.Wpf.Views.Assets.AssetDistributionView"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:globalization="clr-namespace:Neo.Gui.Globalization.Resources;assembly=Neo.Gui.Globalization"
-        xmlns:assets="clr-namespace:Neo.Gui.ViewModels.Assets;assembly=Neo.Gui.ViewModels"
-        xmlns:controls="clr-namespace:Neo.Gui.Wpf.Controls"
-        xmlns:markupExtensions="clr-namespace:Neo.Gui.Wpf.MarkupExtensions"
-        DataContext="{markupExtensions:DataContextBinding ViewModel=assets:AssetDistributionViewModel}"
-        Title="{x:Static globalization:Strings.AssetDistributionTitle}"
-        Width="540" Height="490" ResizeMode="NoResize">
+﻿<controls:NeoWindow 
+    x:Class="Neo.Gui.Wpf.Views.Assets.AssetDistributionView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:globalization="clr-namespace:Neo.Gui.Globalization.Resources;assembly=Neo.Gui.Globalization"
+    xmlns:assets="clr-namespace:Neo.Gui.ViewModels.Assets;assembly=Neo.Gui.ViewModels"
+    xmlns:controls="clr-namespace:Neo.Gui.Wpf.Controls"
+    xmlns:markupExtensions="clr-namespace:Neo.Gui.Wpf.MarkupExtensions"
+    DataContext="{markupExtensions:DataContextBinding ViewModel=assets:AssetDistributionViewModel}"
+    Title="{x:Static globalization:Strings.AssetDistributionTitle}"
+    Width="540" 
+    Height="490" 
+    ResizeMode="NoResize">
+    
     <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -49,7 +53,7 @@
         </GroupBox>
 
         <GroupBox Grid.Row="2" Header="{x:Static globalization:Strings.Distribution}" IsEnabled="{Binding DistributionEnabled}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-            <controls:TransactionOutputListBox Items="{Binding Items}" Asset="{Binding Asset}" ItemsChanged="TxOutListBox_OnItemsChanged" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+            <controls:TransactionOutputListBox Items="{Binding Items}" Asset="{Binding Asset}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
         </GroupBox>
 
         <DockPanel Grid.Row="3" Margin="0 8 0 0" HorizontalAlignment="Right" VerticalAlignment="Stretch">

--- a/Neo.Gui.Wpf/Views/Assets/AssetDistributionView.xaml.cs
+++ b/Neo.Gui.Wpf/Views/Assets/AssetDistributionView.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Neo.Gui.Dialogs.Interfaces;
+﻿using Neo.Gui.Dialogs.Interfaces;
 using Neo.Gui.Dialogs.LoadParameters.Assets;
 
 namespace Neo.Gui.Wpf.Views.Assets
@@ -9,14 +8,6 @@ namespace Neo.Gui.Wpf.Views.Assets
         public AssetDistributionView()
         {
             InitializeComponent();
-        }
-
-        private void TxOutListBox_OnItemsChanged(object sender, EventArgs e)
-        {
-            // TODO #Issue 145 [AboimPinto]: need to find in the ViewModel a way to enable the confirm buttom
-
-            //var viewModel = this.DataContext as AssetDistributionViewModel;
-            //viewModel.UpdateConfirmButtonEnabled();
         }
     }
 }


### PR DESCRIPTION
Link to the ObservableCollection changed event avoid to use the Code-Behind code

#145 
